### PR TITLE
Use libc::c_char for FFI strings

### DIFF
--- a/src/neqo-future-sys/Cargo.toml
+++ b/src/neqo-future-sys/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["staticlib"]
 [dependencies]
 async-std = { version = "*", features = ["unstable"] }
 futures = "*"
+libc = "0.2"
 
 neqo-crypto = { tag = "v0.4.8", git = "https://github.com/mozilla/neqo" }
 neqo-future = { path = "./../neqo-future/" }


### PR DESCRIPTION
It will make the parameters more clear what they do, and helps other tools like [cbindgen](https://github.com/eqrion/cbindgen).